### PR TITLE
Fix more uncommon code styles

### DIFF
--- a/src/Utils/CodeCleanUp/Tasks/Task/QuoteUndefinedConstantsInSquareBrackets.php
+++ b/src/Utils/CodeCleanUp/Tasks/Task/QuoteUndefinedConstantsInSquareBrackets.php
@@ -28,7 +28,7 @@ class QuoteUndefinedConstantsInSquareBrackets extends TaskAbstract implements Ta
         $spacer = '[' . $spacerChars . ']*';
 
         // append single quotes around variables where they are missing
-        $pattern = '`(\$[a-zA-Z0-9_]+' . $spacer . ')(\[[\$a-zA-Z0-9_\[\]' . $spacerChars . ']+\])`';
+        $pattern = '`(\$[a-zA-Z0-9_]+' . $spacer . ')(\[[\$a-zA-Z0-9_#\'\[\]' . $spacerChars . ']+\])`';
         $text = preg_replace_callback($pattern, function($matches) use ($spacer, $definedConstants) {
             $pattern = '`(\[' . $spacer . ')([a-zA-Z0-9_]+)(' . $spacer . '\])`';
 
@@ -53,7 +53,7 @@ class QuoteUndefinedConstantsInSquareBrackets extends TaskAbstract implements Ta
         }, $data);
 
         // fix - add "{", "}" - array definitions (old-style) inside double quoted strings (nested-quotes)
-        $pattern = '`"[^"]*"`U';
+            $pattern = '`(\'[^\']*\'|\?>.*<\?(=|php))(*SKIP)(*F)|".*"`Us';
         $text = preg_replace_callback($pattern, function($matches) {
             return $this->fixAddCurlyBrackets($matches[0]);
         }, $text);
@@ -81,13 +81,9 @@ class QuoteUndefinedConstantsInSquareBrackets extends TaskAbstract implements Ta
      */
     private function fixAddCurlyBrackets($text)
     {
-        $pattern = '`(.{1})(\$[a-zA-Z0-9_]+\[\'.+\'\])(.{1})`';
+            $pattern = '`(?<!\{)\$[a-zA-Z0-9_]+(?:\[\'[^\']+\'\])+(?!\})`s';
         return preg_replace_callback($pattern, function($matches) {
-            $arrayString = $matches[2];
-            if ('{' !== $matches[1] && '}' !== $matches[3]) {
-                $arrayString = '{' . $arrayString . '}';
-            }
-            return $matches[1] . $arrayString . $matches[3];
+            return '{' . $matches[0] . '}';
         }, $text);
     }
 }

--- a/testing/data/Utils/tasks/QuoteUndefinedConstantsInSquareBrackets/nested-quotes.php
+++ b/testing/data/Utils/tasks/QuoteUndefinedConstantsInSquareBrackets/nested-quotes.php
@@ -29,3 +29,25 @@ echo "I am already properly defined here {$array['key']} and must remain as I am
 // multidimensional arrays inside quotes
 echo "$array[key1][key2]";
 echo "$array[key1][key2][key3]";
+
+print_r($datadata[TimeInTransitResponse]['#'][TransitResponse][0]['#'][ServiceSummary][0]['#']);
+
+$request = "<?php xml version=\"1.0\"?>
+<AccessRequest xml:lang=\"en-US\">
+<?php xml version=\"1.0\"?>
+
+         <CompanyName>$ship_to[company_name]</CompanyName>
+         <AttentionName>$ship_to[attn_name]</AttentionName>
+";
+
+echo '<td><strong><a href="file.php?getparam='.$_GET[getparam].'">linkname</a></strong></td>';
+
+$designerlist.="<option value=\"$designer[designerid]\" $designerselector>$designer[designername]</option>";
+
+$identifier=stripslashes(substr("$openinfo[username]-$openinfo[orderid]",0,15) . "...");
+?>
+<tr>
+    <td colspan="4" bgcolor="CBC8CE">
+        <a href="ordermanager.php?director=<?= $_GET[director] ?>">Prev Month</a>
+    </td>
+</tr>

--- a/testing/data/Utils/tasks/QuoteUndefinedConstantsInSquareBrackets/nested-quotes_expected.php
+++ b/testing/data/Utils/tasks/QuoteUndefinedConstantsInSquareBrackets/nested-quotes_expected.php
@@ -29,3 +29,25 @@ echo "I am already properly defined here {$array['key']} and must remain as I am
 // multidimensional arrays inside quotes
 echo "{$array['key1']['key2']}";
 echo "{$array['key1']['key2']['key3']}";
+
+print_r($datadata['TimeInTransitResponse']['#']['TransitResponse'][0]['#']['ServiceSummary'][0]['#']);
+
+$request = "<?php xml version=\"1.0\"?>
+<AccessRequest xml:lang=\"en-US\">
+<?php xml version=\"1.0\"?>
+
+         <CompanyName>{$ship_to['company_name']}</CompanyName>
+         <AttentionName>{$ship_to['attn_name']}</AttentionName>
+";
+
+echo '<td><strong><a href="file.php?getparam='.$_GET['getparam'].'">linkname</a></strong></td>';
+
+$designerlist.="<option value=\"{$designer['designerid']}\" $designerselector>{$designer['designername']}</option>";
+
+$identifier=stripslashes(substr("{$openinfo['username']}-{$openinfo['orderid']}",0,15) . "...");
+?>
+<tr>
+    <td colspan="4" bgcolor="CBC8CE">
+        <a href="ordermanager.php?director=<?= $_GET['director'] ?>">Prev Month</a>
+    </td>
+</tr>


### PR DESCRIPTION
Tried running the tool against a large legacy code base. Ran into several problem which I added to the unit test and tried to fix by tweaking the Regular expressions. I think it's in a pretty good spot now and I was able fix 2700 lines of code with one command. There were a few edge cases that still don't work but I thought it's good enough now. 
Ideally we'd use a token parser instead of regex but that's more effort than I wish to make.